### PR TITLE
Improvements to the submission script

### DIFF
--- a/create_submission.sh
+++ b/create_submission.sh
@@ -1,21 +1,17 @@
 #!/usr/bin/env bash
 
-if [[ "$1" == "--help" ]]; then
-  echo "Usage: $(basename $0) FILE YOUR_NAME MATR_NR EX_NR"
+if [[ "$1" == "--help" || $# != 4 ]]; then
+  echo "Usage: $0 FILE YOUR_NAME MATR_NR EX_NR"
   exit 0
 fi
 
 TARGET="submissions"
 mkdir -p $TARGET
 
-PREFIX="\"\"\"ex$4.py
+cat - $1 <<EOF | tee "$TARGET/ex$4.py"
+"""ex$4.py
 Author: $2
 Matr.Nr.: $3
 Exercise $4
-\"\"\"
-"
-PYTHON_CONTENT=$(cat $1)
-CONTENT="$PREFIX$PYTHON_CONTENT"
-
-echo "$CONTENT"
-echo "$CONTENT" > "$TARGET/ex$4.py"
+"""
+EOF


### PR DESCRIPTION
Remove `basename` because it will print a wrong path if the script is started from another directory, or it is not on the system PATH variable. Also, print help if a wrong number of arguments was given.
Instead of reading the python file, and putting the header into a variable which are then combined, use the `cat` tool to combine and a heredoc to define the header.